### PR TITLE
CI: standardize Actions (paths + concurrency + runners)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,11 +3,31 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "examples/**"
+      - "Cargo.toml"
+      - "specs/**"
+      - "specsync.json"
+      - ".github/workflows/ci.yml"
   pull_request:
     branches: [main]
+    paths:
+      - "src/**"
+      - "tests/**"
+      - "examples/**"
+      - "Cargo.toml"
+      - "specs/**"
+      - "specsync.json"
+      - ".github/workflows/ci.yml"
 
 permissions:
   contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 env:
   CARGO_TERM_COLOR: always
@@ -15,12 +35,13 @@ env:
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
         rust: [stable, beta, "1.85"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust ${{ matrix.rust }}
         uses: dtolnay/rust-toolchain@master
@@ -35,8 +56,9 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -51,8 +73,9 @@ jobs:
 
   specs:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Spec validation
         uses: CorvidLabs/spec-sync@v2.1.0


### PR DESCRIPTION
Standardizes `.github/workflows/ci.yml` to match the CorvidLabs/merlin CI standard.

- Add `paths:` filters to push and pull_request triggers (scoped to `src/**`, `tests/**`, `examples/**`, `Cargo.toml`, `specs/**`, `specsync.json`, and the workflow file) so docs/README-only changes no longer trigger the 3-version test matrix, clippy, and spec-sync.
- Add a `concurrency:` group with `cancel-in-progress: true` so superseded pushes/PR updates cancel redundant in-flight runs.
- Bump `actions/checkout@v4` to `@v5` and add `timeout-minutes` to each job.
- Runners remain GitHub-hosted `ubuntu-latest` (correct for a PUBLIC repo; never self-hosted).
- Cargo.lock is gitignored for this library crate, so it is intentionally omitted from the paths set.

Mirrors the CorvidLabs/merlin CI standard.